### PR TITLE
Add methods to get MIDI in devices count and names

### DIFF
--- a/src/ofx/MidiIn.cpp
+++ b/src/ofx/MidiIn.cpp
@@ -73,6 +73,16 @@ void pdsp::midi::Input::listPorts(){
     midiIn.listInPorts(); // print input ports to console
 }
 
+int pdsp::midi::Input::getPortCount()
+{
+  return midiIn.getNumInPorts();
+}
+
+std::vector<std::string> pdsp::midi::Input::getPortList()
+{
+  return midiIn.getInPortList();
+}
+
 
 void pdsp::midi::Input::prepareToPlay( int expectedBufferSize, double sampleRate ){
     oneSlashMicrosecForSample = 1.0 / (1000000.0 / sampleRate);

--- a/src/ofx/MidiIn.h
+++ b/src/ofx/MidiIn.h
@@ -55,6 +55,16 @@ public:
     void listPorts();
 
     /*!
+    @brief return number of available midi in ports
+    */
+    int getPortCount();
+
+    /*!
+    @brief return list of available ports name
+    */
+    std::vector<std::string> getPortList();
+
+    /*!
     @brief uses an already open ofxMidiIn instead of opening a port
     @param[in] midiInput ofxMidiIn object
     */    


### PR DESCRIPTION
Hi,

I have added methods to get number and names of MIDI In ports.
If you want to integrate it in your repo.

This my first pull request, not very sur how to do :-)

ADD: int getPortCount();
ADD: std::vector<std::string> getPortList();