### PR TITLE
Use map instead of vector for MidiControls

### DIFF
--- a/src/ofx/MidiControls.cpp
+++ b/src/ofx/MidiControls.cpp
@@ -24,11 +24,15 @@ void pdsp::midi::Controls::setCCSlew(float slewTimeMs){
     }
 }
 
-void pdsp::midi::Controls::setMaxCCNum(int ccNum){
+void pdsp::midi::Controls::setMaxCCNum(int ccNum) {
 }
 
-int pdsp::midi::Controls::getMaxCCNum(){
-    return midiCC.getCCSize();
+int pdsp::midi::Controls::getMinCCNum() {
+    return outs_cc.begin()->first;
+}
+
+int pdsp::midi::Controls::getMaxCCNum() {
+    return outs_cc.rbegin()->first;
 }
 
 int pdsp::midi::Controls::getCCSize() {

--- a/src/ofx/MidiControls.cpp
+++ b/src/ofx/MidiControls.cpp
@@ -4,54 +4,47 @@
 #ifndef __ANDROID__
 
 pdsp::midi::Controls::Controls(){
-    setMaxCCNum(midiCC.getCCSize());
-    setCCSlew(50.0f);   
+    setCCSlew(50.0f);
 }
 
-
 pdsp::midi::Controls::Controls(int maxCC){
-    setMaxCCNum(maxCC);
-    setCCSlew(50.0f);   
+    setCCSlew(50.0f);
 }
 
 void pdsp::midi::Controls::processMidi(const pdsp::midi::Input &midiInProcessor, const int &bufferSize ) noexcept{
     midiCC.processMidi(midiInProcessor.getMessageVector(), bufferSize);
 }
 
-
 void pdsp::midi::Controls::setCCSlew(float slewTimeMs){
     this->slewTime = slewTimeMs;
-    
-    for(int i=0; i<midiCC.getCCSize(); ++i){
-        outs_cc[i].setSlewRateModeReference(1.0f);
-        outs_cc[i].setSlewTime(slewTimeMs, pdsp::Rate);
+
+    for (auto& cc : outs_cc) {
+        cc.second.setSlewRateModeReference(1.0f);
+        cc.second.setSlewTime(slewTimeMs, pdsp::Rate);
     }
 }
 
-
 void pdsp::midi::Controls::setMaxCCNum(int ccNum){
-    midiCC.setMaxCCNum(ccNum);
-    outs_cc.resize(midiCC.getCCSize());
-    setCCSlew(slewTime);
-    for(int i=0; i<midiCC.getCCSize(); ++i){
-        midiCC.ccMessages[i] >> outs_cc[i];
-    }
-    midiCC.clearAll();
 }
 
 int pdsp::midi::Controls::getMaxCCNum(){
     return midiCC.getCCSize();
 }
 
+int pdsp::midi::Controls::getCCSize() {
+    return midiCC.getCCSize();
+}
 
-pdsp::SequencerValueOutput & pdsp::midi::Controls::out( int cc ) {
-    if( cc < 0 ){
-        cc = - cc;
+pdsp::SequencerValueOutput & pdsp::midi::Controls::out(int cc) {
+    if (cc < 0) {
+        cc = -cc;
     }
-    if( cc > getMaxCCNum() ){
-        setMaxCCNum(cc);
+    if (outs_cc.find(cc) == outs_cc.end()) {
+        outs_cc[cc].setSlewRateModeReference(1.0f);
+        outs_cc[cc].setSlewTime(slewTime, pdsp::Rate);
+        midiCC.out(cc) >> outs_cc[cc];
     }
     return outs_cc[cc];
 }
-    
+
 #endif

--- a/src/ofx/MidiControls.h
+++ b/src/ofx/MidiControls.h
@@ -35,12 +35,12 @@ public:
     void setCCSlew(float slewTimeMs);
 
     /*!
-    @brief returns the min CC out
+    @brief returns the lowest CC out
     */
     int  getMinCCNum();
 
     /*!
-    @brief returns the max CC out
+    @brief returns the highest CC out
     */
     int  getMaxCCNum();
 

--- a/src/ofx/MidiControls.h
+++ b/src/ofx/MidiControls.h
@@ -11,21 +11,23 @@
 #include "ofxMidi.h"
 #include "../DSP/control/SequencerValueOutput.h"
 #include <chrono>
+#include <map>
 #include "helper/MidiCCBuffers.h"
 #include "helper/Controller.h"
 #include "MidiIn.h"
 
 /*!
-@brief utility class to parse control change data from a pdsp::midi::Input and convert it to a bank of patchable modules with optional slewed output. By default outputs are slewed to 50ms. 
+@brief utility class to parse control change data from a pdsp::midi::Input and convert it to a bank of patchable modules with optional slewed output. By default outputs are slewed to 50ms.
 */
 
 namespace pdsp{ namespace midi {
 
 class Controls : public pdsp::Controller {
-    
+
 public:
     Controls();
     Controls(int maxCC);
+
     /*!
     @brief sets the slew times of the CCs
     @param[in] slewTimeMs new slew time in milliseconds
@@ -33,37 +35,40 @@ public:
     void setCCSlew(float slewTimeMs);
 
     /*!
-    @brief sets the max CC number parsed, and resizes the out_cc vector
-    @param[in] slewTimeMs new slew time in milliseconds
+    @brief returns number of CC outs
     */
-    void setMaxCCNum(int ccNum);
-
-
-    /*!
-    @brief returns the number of the max returned CC
-    @param[in] slewTimeMs new slew time in milliseconds
-    */
-    int  getMaxCCNum();
+    int getCCSize();
 
     /*!
     @brief returns a control value corrisponding to the given cc number, the output is mapped to the 0.0f-1.0f range.
     @param[in] cc the cc number for the output
-    */    
+    */
     pdsp::SequencerValueOutput & out( int cc );
-    
+
 /*!
     @cond HIDDEN_SYMBOLS
 */
-    std::vector<pdsp::SequencerValueOutput>    outs_cc; // this has to become private in later versions
-    
-    void processMidi(const pdsp::midi::Input &midiInProcessor, const int &bufferSize ) noexcept override;   
+    std::map<int, pdsp::SequencerValueOutput> outs_cc; // this has to become private in later versions
+
+    void processMidi(const pdsp::midi::Input &midiInProcessor, const int &bufferSize ) noexcept override;
+
+    /*!
+    @brief does nothing
+    @param[in] ccNum
+    */
+    void setMaxCCNum(int ccNum);
+
+    /*!
+    @brief returns the number of CC outs
+    */
+    int  getMaxCCNum();
 /*!
-    @endcond 
+    @endcond
 */
-private: 
+private:
     float slewTime;
     pdsp::helper::MidiCCBuffers midiCC;
-        
+
 };
 
 }} // end namespaces

--- a/src/ofx/MidiControls.h
+++ b/src/ofx/MidiControls.h
@@ -35,6 +35,16 @@ public:
     void setCCSlew(float slewTimeMs);
 
     /*!
+    @brief returns the min CC out
+    */
+    int  getMinCCNum();
+
+    /*!
+    @brief returns the max CC out
+    */
+    int  getMaxCCNum();
+
+    /*!
     @brief returns number of CC outs
     */
     int getCCSize();
@@ -57,11 +67,6 @@ public:
     @param[in] ccNum
     */
     void setMaxCCNum(int ccNum);
-
-    /*!
-    @brief returns the number of CC outs
-    */
-    int  getMaxCCNum();
 /*!
     @endcond
 */

--- a/src/ofx/helper/MidiCCBuffers.cpp
+++ b/src/ofx/helper/MidiCCBuffers.cpp
@@ -9,56 +9,52 @@ namespace pdsp{ namespace helper{
 
 MidiCCBuffers::MidiCCBuffers(){
     sendClearMessages = true;
-  
-    setMaxCCNum(9);
-    for(int i=0; i<ccSize; ++i){
-        ccMessages[i].reserve(MIDICCBUFFERSMESSAGERESERVE);
-    }  
 }
-
-
 
 void MidiCCBuffers::clearAll(){
     sendClearMessages = true;
 }
 
 void MidiCCBuffers::setMaxCCNum(int maxCC){
-    if(maxCC>0){
-        ccSize = maxCC+1;
-        ccMessages.resize(ccSize);
-        for (int i=0; i<ccSize; i++){
-            ccMessages[i].reserve(MIDICCBUFFERSMESSAGERESERVE);
-        }
+}
+
+pdsp::MessageBuffer & MidiCCBuffers::out(int cc) {
+    if (ccMessages.find(cc) == ccMessages.end()) {
+        ccMessages[cc].reserve(MIDICCBUFFERSMESSAGERESERVE);
     }
+    return ccMessages[cc];
+}
+
+int MidiCCBuffers::getCCSize() {
+    return ccMessages.size();
 }
 
 void MidiCCBuffers::processMidi (const std::vector<_PositionedMidiMessage> & readVector, const int &bufferSize ){
     //clear buffers
 
-    for(int i=0; i<ccSize; ++i){
-        ccMessages[i].clearMessages();
+    for (auto& cc : ccMessages) {
+        cc.second.clearMessages();
     }
-    
-    if(sendClearMessages){
-        for(int i=0; i<ccSize; ++i){
-            ccMessages[i].addMessage(0.0f, 0);
-        }
-        sendClearMessages = false;  
-    }
-    
-    for(const _PositionedMidiMessage &midi : readVector){
 
-        if(midi.message.status==MIDI_CONTROL_CHANGE && midi.message.control < ccSize){
-            float value = static_cast<float>(midi.message.value +1 )*0.0078125f; 
-            if (value==0.0078125f){ value = 0.0f; }
-            ccMessages[midi.message.control].addMessage(value, midi.sample); 
+    if(sendClearMessages){
+        for (auto& cc : ccMessages) {
+            cc.second.addMessage(0.0f, 0);
+        }
+        sendClearMessages = false;
+    }
+
+    for(const _PositionedMidiMessage &midi : readVector){
+        if (midi.message.status == MIDI_CONTROL_CHANGE && ccMessages.find(midi.message.control) != ccMessages.end()) {
+            float value = static_cast<float>(midi.message.value + 1) * 0.0078125f;
+            if (value == 0.0078125f) { value = 0.0f; }
+            ccMessages[midi.message.control].addMessage(value, midi.sample);
         }
     }
-    
-    for(int i=0; i<ccSize; ++i){
-        ccMessages[i].processDestination(bufferSize);
+
+    for (auto& cc : ccMessages) {
+        cc.second.processDestination(bufferSize);
     }
-    
+
 }
 
 }} // end namespace

--- a/src/ofx/helper/MidiCCBuffers.h
+++ b/src/ofx/helper/MidiCCBuffers.h
@@ -10,6 +10,7 @@
 
 #include "ofxMidi.h"
 #include "../messages/header.h"
+#include <map>
 #include "PositionedMidiMessage.h"
 
 namespace pdsp{ namespace helper {
@@ -19,22 +20,26 @@ public:
     MidiCCBuffers();
 
     void processMidi (const std::vector<_PositionedMidiMessage> & readVector, const int &bufferSize );
-    
+
     void clearAll();
-    
+
+    pdsp::MessageBuffer & out(int cc);
+
+    int getCCSize();
+
+    std::map<int, pdsp::MessageBuffer> ccMessages;
+
+    /*!
+        @cond HIDDEN_SYMBOLS
+    */
     void setMaxCCNum(int maxCC);
-    
-    int getCCSize(){ return ccSize; }
-
-    std::vector<pdsp::MessageBuffer>     ccMessages;
-
-
+    /*!
+        @endcond
+    */
 
 private:
+    bool sendClearMessages;
 
-    bool    sendClearMessages; 
-    int     ccSize;
-    
 };
 
 }}


### PR DESCRIPTION
`void setMaxCCNum(int ccNum)` does nothing now. `int getMaxCCNum()` and `int getMinCCNum()` (new) both work as expected. `int getCCSize()` has been added to MidiControls, too.

Compiles and works with basic testing!