### PR TITLE
Change partialsTable to static map

### DIFF
--- a/src/DSP/oscillators/wavetable/DataTable.h
+++ b/src/DSP/oscillators/wavetable/DataTable.h
@@ -6,6 +6,7 @@
 #define PDSP_OSC_DATATABLE_H_INCLUDED
 
 #include "../pdspCore.h"
+#include <map>
 
 namespace pdsp {
     
@@ -86,7 +87,7 @@ private:
     int length;
 
     int maxPartials;
-    float ** partialsTable;    
+    static std::map<int, std::vector<float*>> partialsTable;
 
     float * bufferNew;            
 	std::vector<float> vData;

--- a/src/DSP/oscillators/wavetable/WaveTable.h
+++ b/src/DSP/oscillators/wavetable/WaveTable.h
@@ -4,6 +4,7 @@
 
 
 #include "../../samplers/SampleBuffer.h"
+#include <map>
 
 namespace pdsp {
     
@@ -201,7 +202,7 @@ private:
     bool verbose;
 
     int maxPartials;
-    float ** partialsTable;    
+    static std::map<int, std::vector<float*>> partialsTable;
         
     SampleBuffer loader;
 };    


### PR DESCRIPTION
I created a static map of int (table length) to vector (partial index) of float pointers (wave table). This way, any two wave tables or data tables that share the same table length can reuse the same floats.

I also changed how the wave tables and data tables are normalized. Sawtooth wave was coming out a little quiet, and so normalizing it the proper way was something I wanted to do.