### PR TITLE
Change visibility of Wrapper member functions

### DIFF
--- a/src/ofx/Wrapper.h
+++ b/src/ofx/Wrapper.h
@@ -53,11 +53,11 @@ protected:
     */
     virtual void audioProcess(float *input, int bufferSize, int nChannels) = 0;
 
+    void prepareUnit(int expectedBufferSize, double sampleRate) override;
+    void releaseResources() override;
+
 private:
     void process(int bufferSize) noexcept override;
-
-    void prepareUnit( int expectedBufferSize, double sampleRate ) override;
-    void releaseResources() override;
     
     int bufferLength;
     int maxChannels;


### PR DESCRIPTION
This may seem like a minor thing, but I needed to override Wrapper's `prepareUnit` function, and so I'm assuming that others may want to do the same. Just remember to call the superclass function!