### PR TITLE
Add remove controller, external out, osc in functions

### DIFF
--- a/src/ofx/Engine.cpp
+++ b/src/ofx/Engine.cpp
@@ -382,7 +382,6 @@ void pdsp::Engine::audioIn (ofSoundBuffer &inBuffer) {
 
 #ifndef __ANDROID__
 void pdsp::Engine::addMidiController( pdsp::Controller & controller, pdsp::midi::Input & midiIn ){
-    
     bool midiInFound = false;
     for( pdsp::midi::Input * &ptr : midiIns ){
         if( ptr == &midiIn ){
@@ -407,11 +406,38 @@ void pdsp::Engine::addMidiController( pdsp::Controller & controller, pdsp::midi:
         controllerLinkedMidis.push_back( &midiIn );
     }    
     hasMidiIn = true;
-    
+}
+
+void pdsp::Engine::removeMidiController(pdsp::Controller & controller, pdsp::midi::Input & midiIn) {
+    for (int i = 0; i < controllers.size(); ++i) {
+        if (controllers[i] == &controller && controllerLinkedMidis[i] == &midiIn) {
+            std::iter_swap(controllers.begin() + i, controllers.end() - 1);
+            std::iter_swap(controllerLinkedMidis.begin() + i, controllerLinkedMidis.end() - 1);
+            controllers.pop_back();
+            controllerLinkedMidis.pop_back();
+            break;
+        }
+    }
+
+    if (std::find(controllerLinkedMidis.begin(), controllerLinkedMidis.end(), &midiIn) == controllerLinkedMidis.end()) {
+        auto it = std::find(midiIns.begin(), midiIns.end(), &midiIn);
+        if (it != midiIns.end()) {
+            std::iter_swap(it, midiIns.end() - 1);
+            midiIns.pop_back();
+        }
+    }
+
+    if (midiIns.empty()) {
+        hasMidiIn = false;
+    }
 }
 
 void  pdsp::Engine::addMidiOut( pdsp::midi::Output & midiOut ){
     addExternalOut( midiOut );
+}
+
+void pdsp::Engine::removeMidiOut( pdsp::midi::Output & midiOut ){
+    removeExternalOut( midiOut );
 }
 #endif
 
@@ -420,11 +446,14 @@ void  pdsp::Engine::addMidiOut( pdsp::midi::Output & midiOut ){
 void pdsp::Engine::addSerialOut( pdsp::serial::Output & serialOut ) {
     addExternalOut( serialOut ); 
 }
+
+void pdsp::Engine::removeSerialOut( pdsp::serial::Output & serialOut ) {
+    removeExternalOut( serialOut );
+}
 #endif
 #endif
 
 void pdsp::Engine::addExternalOut( pdsp::ExtSequencer & externalOut ) {
-   
     bool externalOutFound = false;
     for( pdsp::ExtSequencer * &ptr : externalOuts ){
         if( ptr == &externalOut ){
@@ -437,6 +466,17 @@ void pdsp::Engine::addExternalOut( pdsp::ExtSequencer & externalOut ) {
         externalOuts.push_back( &externalOut );
     }
     hasExternalOut = true;
+}
+
+void pdsp::Engine::removeExternalOut(pdsp::ExtSequencer & externalOut) {
+    auto it = std::find(externalOuts.begin(), externalOuts.end(), &externalOut);
+    if (it != externalOuts.end()) {
+        std::iter_swap(it, externalOuts.end() - 1);
+        externalOuts.pop_back();
+    }
+    if (externalOuts.empty()) {
+        hasExternalOut = false;
+    }
 }
 
 void pdsp::Engine::addOscInput( pdsp::osc::Input & oscInput ) {
@@ -452,6 +492,17 @@ void pdsp::Engine::addOscInput( pdsp::osc::Input & oscInput ) {
         oscIns.push_back( &oscInput );
     }
     hasOscIn = true;    
+}
+
+void pdsp::Engine::removeOscInput(pdsp::osc::Input & oscInput) {
+    auto it = std::find(oscIns.begin(), oscIns.end(), &oscInput);
+    if (it != oscIns.end()) {
+        std::iter_swap(it, oscIns.end() - 1);
+        oscIns.pop_back();
+    }
+    if (oscIns.empty()) {
+        hasOscIn = false;
+    }
 }
 
 void pdsp::Engine::test( bool testingActive, float testingDB ){

--- a/src/ofx/Engine.h
+++ b/src/ofx/Engine.h
@@ -104,6 +104,8 @@ public:
     */
     void addOscInput( pdsp::osc::Input & oscInput );
 
+    void removeOscInput( pdsp::osc::Input & oscInput );
+
 #ifndef __ANDROID__
     /*!
     @brief adds a midi controller and a relative midi input to the engine, making them active.
@@ -113,11 +115,15 @@ public:
     */
     void addMidiController( pdsp::Controller & controller, pdsp::midi::Input & midiIn );
 
+    void removeMidiController( pdsp::Controller & controller, pdsp::midi::Input & midiIn );
+
     /*!
     @brief adds a midi output to the engine, making it active.
     @param[in] midiOut midi out object to activate
     */
     void addMidiOut( pdsp::midi::Output & midiOut );
+
+    void removeMidiOut( pdsp::midi::Output & midiOut );
 
 #ifndef TARGET_OF_IOS
     /*!
@@ -125,6 +131,8 @@ public:
     @param[in] serialOut serial out object to activate
     */
     void addSerialOut( pdsp::serial::Output & serialOut );
+
+    void removeSerialOut( pdsp::serial::Output & serialOut );
 #endif // TARGET_OF_IOS
 #endif // __ANDROID__
     
@@ -133,6 +141,8 @@ public:
     @param[in] externalOut external out object to activate
     */
     void addExternalOut( pdsp::ExtSequencer & externalOut );
+
+    void removeExternalOut( pdsp::ExtSequencer & externalOut );
 
     /*!
     @brief returns a Patchable object that represent the audio out of the system. Patch your module to this for connecting them to the selected device audio output.


### PR DESCRIPTION
Add the following functions
```
void removeOscInput( pdsp::osc::Input & oscInput );
void removeMidiController( pdsp::Controller & controller, pdsp::midi::Input & midiIn );
void removeMidiOut( pdsp::midi::Output & midiOut );
void removeSerialOut( pdsp::serial::Output & serialOut );
void removeExternalOut( pdsp::ExtSequencer & externalOut );
```
Obviously, probably should not call while the engine is running...
Current implementation will swap elements (element to remove and final element) before removing for efficiency. This can cause unwanted effects, especially with OSC input and ordering of tempo changes. Let me know if implementation should change or if these functions cause other unwanted effects.