### PR TITLE
Add instances for ExtSequencer, OscInput, and MidiIn

### DIFF
--- a/src/math/header.h
+++ b/src/math/header.h
@@ -21,6 +21,7 @@
 #include "interpolation/cosine.h"
 #include "interpolation/smooth.h"
 #include "interpolation/hermite.h"
+#include "interpolation/cubic.h"
 
 #include "dsphelpers/nonlinear1.h"
 #include "dsphelpers/phazorShifter.h"

--- a/src/math/interpolation/cubic.h
+++ b/src/math/interpolation/cubic.h
@@ -1,0 +1,23 @@
+
+
+#ifndef PDSP_MATH_CUBIC_H_INCLUDED
+#define PDSP_MATH_CUBIC_H_INCLUDED
+
+#include "../functions.h"
+
+namespace pdsp {
+
+    inline_f float interpolate_cubic(const float x0, const float x1, const float x2, const float x3, const float mu) {
+
+        float mu2 = mu * mu;
+        float a = x3 - x2 + x1 - x0;
+        float b = x0 - x1 - a;
+        float c = x2 - x0;
+
+        return x1 + a * mu2 * mu + b * mu2 + c * mu;
+
+    }
+
+}
+
+#endif  // PDSP_MATH_CUBIC_H_INCLUDED

--- a/src/messages/ExtSequencer.cpp
+++ b/src/messages/ExtSequencer.cpp
@@ -1,0 +1,12 @@
+
+#include "ExtSequencer.h"
+
+std::vector<pdsp::ExtSequencer*> pdsp::ExtSequencer::instances;
+
+pdsp::ExtSequencer::ExtSequencer() {
+    instances.push_back(this);
+}
+
+pdsp::ExtSequencer::~ExtSequencer() {
+    instances.erase(std::remove(instances.begin(), instances.end(), this), instances.end());
+}

--- a/src/messages/ExtSequencer.h
+++ b/src/messages/ExtSequencer.h
@@ -6,20 +6,30 @@
 #ifndef PDSP_MESSAGES_EXTSEQUENCER_H_INCLUDED
 #define PDSP_MESSAGES_EXTSEQUENCER_H_INCLUDED
 
+#include <vector>
+
 namespace pdsp{
 /*!
     @cond HIDDEN_SYMBOLS
 */ 
 class MessageBuffer;
+class Engine;
 
 class ExtSequencer{
+    friend class Engine;
     
 public:
+    ExtSequencer();
+    ~ExtSequencer();
+
     virtual void linkToMessageBuffer(MessageBuffer &messageBuffer) = 0;
     virtual void unlinkMessageBuffer(MessageBuffer &messageBuffer) = 0;
     
     virtual void process( int bufferSize ) = 0;
     virtual void close() = 0;
+
+private:
+    static std::vector<ExtSequencer*> instances;
 };
 /*!
     @endcond

--- a/src/ofx/Engine.cpp
+++ b/src/ofx/Engine.cpp
@@ -421,6 +421,14 @@ void pdsp::Engine::setBackgroundAudio( bool active ){
     bBackgroundAudio = active;
 }
 
+void pdsp::Engine::notifyDisconnectedInput() {
+    inStreamActive = false;
+}
+
+void pdsp::Engine::notifyDisconnectedOutput() {
+    outStreamActive = false;
+}
+
 void pdsp::Engine::setApi( ofSoundDevice::Api api ){
     this->api = api;
 }

--- a/src/ofx/Engine.h
+++ b/src/ofx/Engine.h
@@ -98,10 +98,7 @@ public:
     */
     void setOutputDeviceID(int deviceID);
 
-    /*!
-    @brief adds an OSC input to the engine, making it active.
-    @param[in] oscInput osc input object to activate
-    */
+    [[deprecated("deprecated, handled automatically between construction and destruction")]]
     void addOscInput( pdsp::osc::Input & oscInput );
 
 #ifndef __ANDROID__
@@ -113,25 +110,18 @@ public:
     */
     void addMidiController( pdsp::Controller & controller, pdsp::midi::Input & midiIn );
 
-    /*!
-    @brief adds a midi output to the engine, making it active.
-    @param[in] midiOut midi out object to activate
-    */
+    void removeMidiController( pdsp::Controller & controller, pdsp::midi::Input & midiIn );
+
+    [[deprecated("deprecated, handled automatically between construction and destruction")]]
     void addMidiOut( pdsp::midi::Output & midiOut );
 
 #ifndef TARGET_OF_IOS
-    /*!
-    @brief adds a serial output to the engine, making it active.
-    @param[in] serialOut serial out object to activate
-    */
+    [[deprecated("deprecated, handled automatically between construction and destruction")]]
     void addSerialOut( pdsp::serial::Output & serialOut );
 #endif // TARGET_OF_IOS
 #endif // __ANDROID__
     
-    /*!
-    @brief adds an external output to the engine ( for example an pdsp::serial::Output or an pdsp::midi::Output ) making it active.
-    @param[in] externalOut external out object to activate
-    */
+    [[deprecated("deprecated, handled automatically between construction and destruction")]]
     void addExternalOut( pdsp::ExtSequencer & externalOut );
 
     /*!
@@ -206,17 +196,9 @@ private:
     std::vector<pdsp::ExternalInput> inputs;
 
 #ifndef __ANDROID__
-    std::vector<pdsp::midi::Input*> midiIns;
     std::vector<pdsp::Controller*>  controllers;
     std::vector<pdsp::midi::Input*> controllerLinkedMidis;
-    bool                            hasMidiIn;
 #endif
-
-    std::vector<pdsp::osc::Input*>      oscIns;
-    bool                                hasOscIn;
-
-    std::vector<pdsp::ExtSequencer*>    externalOuts;  
-    bool                                hasExternalOut;
     
     int state;
 

--- a/src/ofx/Engine.h
+++ b/src/ofx/Engine.h
@@ -165,6 +165,16 @@ public:
     */   
     void setBackgroundAudio( bool active );
 
+    /*!
+    @brief notify the engine that input has been disconnected
+    */
+    void notifyDisconnectedInput();
+
+    /*!
+    @brief notify the engine that output has been disconnected
+    */
+    void notifyDisconnectedOutput();
+
 /*!
     @cond HIDDEN_SYMBOLS
 */

--- a/src/ofx/MidiIn.cpp
+++ b/src/ofx/MidiIn.cpp
@@ -6,6 +6,8 @@
 #define OFXPDSP_MIDIREADVECTOR_MESSAGERESERVE 128
 #define OFXPDSP_MIDICIRCULARBUFFER_SIZE 4096
 
+std::vector<pdsp::midi::Input*> pdsp::midi::Input::instances;
+
 pdsp::midi::Input::Input(){
 
     midiIn_p = nullptr;
@@ -15,9 +17,13 @@ pdsp::midi::Input::Input(){
     
     lastread = 0;
     index = 0;
+
+    instances.push_back(this);
 }
 
 pdsp::midi::Input::~Input(){
+    instances.erase(std::remove(instances.begin(), instances.end(), this), instances.end());
+
     closePort();
 }
 

--- a/src/ofx/MidiIn.h
+++ b/src/ofx/MidiIn.h
@@ -17,10 +17,15 @@
 @brief utility class manage midi input ports and collect midi input messages
 */
 
+namespace pdsp {
+class Engine;
+}
+
 namespace pdsp { namespace midi {
     
 class Input : public ofxMidiListener, public pdsp::Preparable {
-    
+    friend class pdsp::Engine;
+
 public:
     Input();
     ~Input();
@@ -105,6 +110,8 @@ private:
     bool connected;
     
     void initPort();
+
+    static std::vector<Input*> instances;
         
 };
 

--- a/src/ofx/OscInput.cpp
+++ b/src/ofx/OscInput.cpp
@@ -4,6 +4,8 @@
 #define OFXPDSP_OSCINPUT_MESSAGERESERVE 128
 #define OFXPDSP_OSCCIRCULARBUFFER_SIZE 10000
 
+std::vector<pdsp::osc::Input*> pdsp::osc::Input::instances;
+
 pdsp::osc::Input::Input() {
     
     parsers.clear();
@@ -22,10 +24,14 @@ pdsp::osc::Input::Input() {
     
     receiver.circularBuffer = &circularBuffer;
     receiver.index = &index;
-}   
+
+    instances.push_back(this);
+}
 
 
 pdsp::osc::Input::~Input(){
+    instances.erase(std::remove(instances.begin(), instances.end(), this), instances.end());
+
     if(connected){
         close();
     }

--- a/src/ofx/OscInput.h
+++ b/src/ofx/OscInput.h
@@ -30,11 +30,16 @@ typedef osc::IpEndpointName _PDSPIpEndpointName_t;
 typedef osc::osc_bundle_element_size_t _PDSPosc_bundle_element_size_t;
 /*!
     @endcond
-*/   
+*/
+
+namespace pdsp {
+class Engine;
+}
 
 namespace pdsp{ namespace osc {
 
 class Input : public pdsp::Preparable {
+    friend class pdsp::Engine;
 
 private:
     
@@ -57,10 +62,11 @@ private:
         void ProcessMessage(const _PDSPOscReceivedMessage_t &m, const _PDSPIpEndpointName_t &remoteEndpoint) override;
     };
 
+    static std::vector<Input*> instances;
+
 public:
-    Input();    
-    ~Input();      
-    
+    Input();
+    ~Input();
 
     /*!
     @brief open the port with the given index
@@ -72,7 +78,6 @@ public:
     @brief shuts down the output
     */   
     void close();
-
 
     /*!
     @brief return true if the port has been sucessfully opened


### PR DESCRIPTION
Add instances for ExtSequencer, OscInput, and MidiIn. MidiIn definitely works.
Also add function `removeMidiController`.

Oops, also left in cubic interpolation code. I'm just going to leave that there.

Slipped in a couple functions to notify engine that stream was disconnected.
They basically just set `inStreamActive` or `outStreamActive` to false.