### PR TITLE
Handle disconnected devices

### DIFF
--- a/src/ofx/Engine.cpp
+++ b/src/ofx/Engine.cpp
@@ -448,9 +448,9 @@ void pdsp::Engine::handleDisconnectedDevices() {
                 }
             }
         }
-        if (outputStream.getSoundStream()->getNumOutputChannels() > 0) {
-            ofSoundDevice outDevice = outputStream.getSoundStream()->getOutDevice();
-            for (ofSoundDevice device : outputStream.getDeviceList()) {
+        if (inputStream.getSoundStream()->getNumOutputChannels() > 0) {
+            ofSoundDevice outDevice = inputStream.getSoundStream()->getOutDevice();
+            for (ofSoundDevice device : inputStream.getDeviceList()) {
                 if (outDevice.name == device.name) {
                     outDeviceFound = true;
                 }

--- a/src/ofx/Engine.cpp
+++ b/src/ofx/Engine.cpp
@@ -132,6 +132,7 @@ void pdsp::Engine::setup( int sampleRate, int bufferSize, int nBuffers){
     if(state!=closedState){ 
         ofLogNotice()<<"[pdsp] engine: changing setup, shutting down stream";
         stop();
+        handleDisconnectedDevices();
         if( inStreamActive ){
             inputStream.close();
         }
@@ -260,6 +261,7 @@ void pdsp::Engine::setup( int sampleRate, int bufferSize, int nBuffers){
 }
 
 void pdsp::Engine::start(){
+    handleDisconnectedDevices();
     if(inStreamActive && state < startedState){
         inputStream.start();
     }
@@ -274,6 +276,7 @@ void pdsp::Engine::start(){
 
 void pdsp::Engine::stop(){
     if(state==startedState){
+        handleDisconnectedDevices();
         if( inStreamActive ){
             inputStream.stop();
         }
@@ -309,6 +312,7 @@ void pdsp::Engine::close(){
         out->close();
     }
 
+    handleDisconnectedDevices();
     if( inStreamActive ){
         inputStream.close();
     }
@@ -430,4 +434,53 @@ void pdsp::Engine::setBackgroundAudio( bool active ){
 
 void pdsp::Engine::setApi( ofSoundDevice::Api api ){
     this->api = api;
+}
+
+void pdsp::Engine::handleDisconnectedDevices() {
+    if (inStreamActive) {
+        bool inDeviceFound = false;
+        bool outDeviceFound = false;
+        if (inputStream.getSoundStream()->getNumInputChannels() > 0) {
+            ofSoundDevice inDevice = inputStream.getSoundStream()->getInDevice();
+            for (ofSoundDevice device : inputStream.getDeviceList()) {
+                if (inDevice.name == device.name) {
+                    inDeviceFound = true;
+                }
+            }
+        }
+        if (outputStream.getSoundStream()->getNumOutputChannels() > 0) {
+            ofSoundDevice outDevice = outputStream.getSoundStream()->getOutDevice();
+            for (ofSoundDevice device : outputStream.getDeviceList()) {
+                if (outDevice.name == device.name) {
+                    outDeviceFound = true;
+                }
+            }
+        }
+        if (!inDeviceFound && !outDeviceFound) {
+            inStreamActive = false;
+        }
+    }
+    if (outStreamActive) {
+        bool inDeviceFound = false;
+        bool outDeviceFound = false;
+        if (outputStream.getSoundStream()->getNumInputChannels() > 0) {
+            ofSoundDevice inDevice = outputStream.getSoundStream()->getInDevice();
+            for (ofSoundDevice device : outputStream.getDeviceList()) {
+                if (inDevice.name == device.name) {
+                    inDeviceFound = true;
+                }
+            }
+        }
+        if (outputStream.getSoundStream()->getNumOutputChannels() > 0) {
+            ofSoundDevice outDevice = outputStream.getSoundStream()->getOutDevice();
+            for (ofSoundDevice device : outputStream.getDeviceList()) {
+                if (outDevice.name == device.name) {
+                    outDeviceFound = true;
+                }
+            }
+        }
+        if (!inDeviceFound && !outDeviceFound) {
+            outStreamActive = false;
+        }
+    }
 }

--- a/src/ofx/Engine.h
+++ b/src/ofx/Engine.h
@@ -177,12 +177,14 @@ public:
 
 private:
 
+    void handleDisconnectedDevices();
+
     ofSoundStream inputStream;
     ofSoundStream outputStream;
     ofSoundDevice::Api api;
     
     bool inStreamActive;
-    bool outStreamActive;    
+    bool outStreamActive;
     
     int inputID;
     int outputID;


### PR DESCRIPTION
Before starting, stopping, or closing streams, check whether both inDevice and outDevice for stream are disconnected (name does not appear in device list), and if so, mark stream as inactive.

Prevents program from freezing when stopping a disconnected stream.
